### PR TITLE
fix: correct date formatting in duplicate report check

### DIFF
--- a/src/app/api/reports/check-duplicate/route.ts
+++ b/src/app/api/reports/check-duplicate/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: Request) {
     const existingReport = await prisma.report.findFirst({
       where: {
         branchId,
-        date: date,
+        date: date.toISOString(),
         reportType,
       },
     });


### PR DESCRIPTION
- Updated the date field in the duplicate report check to use ISO string format for consistency and accuracy in database queries.