### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/lib/telegram.ts
+++ b/src/lib/telegram.ts
@@ -43,5 +43,5 @@ export async function sendTelegramNotification(message: string) {
 export function escapeTelegramMarkdown(text: string): string {
   if (!text) return '';
   // Characters to escape: _ * [ ] ( ) ~ ` > # + - = | { } . !
-  return text.replace(/([_*[\]()~`>#+\-=|{}.!])/g, '\\$1');
+  return text.replace(/([_*[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
 }


### PR DESCRIPTION
Potential fix for [https://github.com/parkkyonghun0510/lc-opd-daily/security/code-scanning/1](https://github.com/parkkyonghun0510/lc-opd-daily/security/code-scanning/1)

To fix the issue, we need to ensure that backslashes are also escaped in the `escapeTelegramMarkdown` function. This can be achieved by including backslashes in the regular expression used for escaping special characters. Specifically, we need to add `\\` to the character set in the regular expression. Since backslashes themselves are special in regular expressions, they must be double-escaped (`\\\\`) to match a literal backslash.

The updated regular expression will now escape all special characters, including backslashes, as required by Telegram MarkdownV2.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
