### PR TITLE
fix: use legacy peer deps and remove force build flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 # Copy package files
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --legacy-peer-deps
 
 # Rebuild the source code only when needed
 FROM base AS builder
@@ -24,7 +24,7 @@ ENV NODE_ENV production
 RUN npx prisma generate
 
 # Build the application with force option to bypass dependency errors
-RUN npm run build:production:force
+RUN npm run build:production
 
 # Production image, copy all the files and run next
 FROM base AS runner


### PR DESCRIPTION
The --legacy-peer-deps flag is needed to resolve dependency conflicts during npm ci. The force build flag is no longer necessary after fixing the dependency issues.